### PR TITLE
Add stricter checking

### DIFF
--- a/dsh
+++ b/dsh
@@ -63,7 +63,7 @@ Connecting via ./dsh shell and running robo build is a common next step."
 # Command: ./dsh shell
 # Connects a shell to the web image as the current user.
 dsh_shell() {
-  if ! docker ps | grep ${PROJECT} > /dev/null; then
+  if ! docker ps | grep ${PROJECT}_web_1 > /dev/null; then
     notice "Project not running, starting."
     dsh_start
   fi
@@ -115,7 +115,7 @@ dsh_purge() {
 # Command: ./dsh status
 # Shows status information about project containers.
 dsh_status() {
-  if ! docker ps | grep ${PROJECT}; then
+  if ! docker ps | grep "\s${PROJECT}_"; then
     notice "${PROJECT} not running."
   fi
 }


### PR DESCRIPTION
Without these changes, any instance of the project name, eg as a branch in another project stops the project starting.

eg, I had other projects running with the shepherd branch of the uofa/apache2-php7-dev:shepherd  image, and that got matched by grep, so shepherd wouldn't start.