### PR TITLE
Set the Drupal install profile from an env var with a sensible defaul…

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -139,6 +139,7 @@ class Handler
                 "\$settings['shepherd_site_id'] = getenv('SHEPHERD_SITE_ID');\n" .
                 "\$settings['shepherd_url'] = getenv('SHEPHERD_URL');\n" .
                 "\$settings['shepherd_token'] = getenv('SHEPHERD_TOKEN_FILE') ? file_get_contents(getenv('SHEPHERD_TOKEN_FILE')) : getenv('SHEPHERD_TOKEN');\n\n" .
+                "\$settings['install_profile'] = getenv('SHEPHERD_INSTALL_PROFILE') ?: 'standard';\n" .
                 "if (getenv('REDIS_ENABLED')) {\n" .
                 "  \$settings['redis.connection']['interface'] = 'PhpRedis';\n" .
                 "  \$settings['redis.connection']['host']      = getenv('REDIS_HOST') ?: 'redis';\n" .
@@ -168,6 +169,7 @@ class Handler
                 $shepherdSettings,
                 FILE_APPEND
             );
+            $this->filesystem->chmod($root . '/sites/default/settings.php', 0444);
         }
     }
 
@@ -180,7 +182,7 @@ class Handler
 
         if (!$this->filesystem->exists($root . '/sites/default/services.yml') && $this->filesystem->exists($root . '/sites/default/default.services.yml')) {
             $this->filesystem->copy($root . '/sites/default/default.services.yml', $root . '/sites/default/services.yml');
-            $this->filesystem->chmod($root . '/sites/default/services.yml', 0666);
+            $this->filesystem->chmod($root . '/sites/default/services.yml', 0444);
         }
     }
 


### PR DESCRIPTION
…t. Also set file permissions to 444 for security.

This can be tested by manually checking out the branch in vendor/universityofadelaide/shepherd-drupal-scaffold.

1. Ensure you have an empty database
2. `rm` your settings.php and services.yml
3. composer install
4. do the Drupal install from web browser