### PR TITLE
Remove dependency check on composer validate.

### DIFF
--- a/RoboFileBase.php
+++ b/RoboFileBase.php
@@ -134,7 +134,6 @@ abstract class RoboFileBase extends \Robo\Tasks {
    */
   public function devComposerValidate() {
     $this->taskComposerValidate()
-      ->withDependencies()
       ->noCheckPublish()
       ->run()
       ->stopOnFail(TRUE);


### PR DESCRIPTION
The withDependencies() just makes the output way too large so that it is ignored, reduce it to just the things we control/care about.

Before:
```
🐳 simon@shepherd:/code$ robo dev:composer-validate | wc -l
 [Composer\Validate] Validating composer.json: /usr/local/bin/composer validate --with-dependencies --no-check-publish
 [Composer\Validate] Running /usr/local/bin/composer validate --with-dependencies --no-check-publish
 [Composer\Validate] Done in 0.718s
143
```

After:
```
🐳 simon@shepherd:/code$ robo dev:composer-validate | wc -l
 [Composer\Validate] Validating composer.json: /usr/local/bin/composer validate --no-check-publish
 [Composer\Validate] Running /usr/local/bin/composer validate --no-check-publish
 [Composer\Validate] Done in 0.78s
4
```