### PR TITLE
Shepherd scaffold no longer runs after composer install by default

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -46,8 +46,6 @@ class Handler
     */
     public function onPostCmdEvent(\Composer\Script\Event $event)
     {
-        $event->getIO()->write("Execute Drupal scaffold.");
-        $this->executeDrupalScaffold($event);
         $event->getIO()->write("Updating Shepherd scaffold files.");
         $this->updateShepherdScaffoldFiles();
         $event->getIO()->write("Creating necessary directories.");
@@ -56,17 +54,6 @@ class Handler
         $this->modifySettingsFile();
         $event->getIO()->write("Removing write permissions on settings files.");
         $this->removeWritePermissions();
-    }
-
-    /**
-     * Run Drupal scaffold handler.
-     */
-    public function executeDrupalScaffold($event)
-    {
-        $root = $this->getDrupalRootPath();
-        $drupalScaffoldHandler = new DrupalScaffoldHandler($event->getComposer(), $event->getIO());
-        $drupalScaffoldHandler->downloadScaffold();
-        $drupalScaffoldHandler->generateAutoload();
     }
 
     /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -38,7 +38,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            ScriptEvents::POST_INSTALL_CMD => 'postCmd',
+            // ScriptEvents::POST_INSTALL_CMD => 'postCmd',
             ScriptEvents::POST_UPDATE_CMD => 'postCmd',
         );
     }


### PR DESCRIPTION
It must now be triggered manually like Drupal scaffold. This means we can remove the "call drupal scaffold during shepherd scaffold" hack.