### PR TITLE
Add in an extra sed to remove _core: default_config_hash:

### DIFF
--- a/RoboFileBase.php
+++ b/RoboFileBase.php
@@ -329,8 +329,7 @@ abstract class RoboFileBase extends \Robo\Tasks {
   protected function configExport($destination = NULL) {
     if ($destination) {
       $this->_exec("$this->drush_cmd -y cex --destination=" . $destination);
-      $this->_exec("sed -i '/^uuid: .*$/d' $this->application_root/$destination/*.yml");
-      $this->_exec("sed -i '/core:/, /default_config_hash:*/d' app/config_new/*.yml $this->application_root/$destination/*.yml");
+      $this->_exec("sed -i '/^uuid:.*$/d; /^_core:$/, /^.*default_config_hash:.*$/d' app/config_new/*.yml $this->application_root/$destination/*.yml");
     }
   }
 

--- a/RoboFileBase.php
+++ b/RoboFileBase.php
@@ -329,7 +329,7 @@ abstract class RoboFileBase extends \Robo\Tasks {
   protected function configExport($destination = NULL) {
     if ($destination) {
       $this->_exec("$this->drush_cmd -y cex --destination=" . $destination);
-      $this->_exec("sed -i '/^uuid:.*$/d; /^_core:$/, /^.*default_config_hash:.*$/d' app/config_new/*.yml $this->application_root/$destination/*.yml");
+      $this->_exec("sed -i '/^uuid:.*$/d; /^_core:$/, /^.*default_config_hash:.*$/d' $this->application_root/$destination/*.yml");
     }
   }
 

--- a/RoboFileBase.php
+++ b/RoboFileBase.php
@@ -330,6 +330,7 @@ abstract class RoboFileBase extends \Robo\Tasks {
     if ($destination) {
       $this->_exec("$this->drush_cmd -y cex --destination=" . $destination);
       $this->_exec("sed -i '/^uuid: .*$/d' $this->application_root/$destination/*.yml");
+      $this->_exec("sed -i '/core:/, /default_config_hash:*/d' app/config_new/*.yml $this->application_root/$destination/*.yml");
     }
   }
 


### PR DESCRIPTION
Add in an extra sed to remove config hash in yml:
`_core:
  default_config_hash: 4bMomowXBbS.....`

Note that this removes core and the default_config_hash - could be a problem if anything else is under _core... maybe we can leave _core and just remove the default_config_hash?