### PR TITLE
Convert to using env var for install profile

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -26,12 +26,4 @@ class RoboFile extends RoboFileBase
         // Put project specific overrides here, below the parent constructor.
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getDrupalProfile()
-    {
-        // Replace this with the profile of your choice.
-        return "standard";
-    }
 }

--- a/RoboFileBase.php
+++ b/RoboFileBase.php
@@ -51,17 +51,19 @@ abstract class RoboFileBase extends \Robo\Tasks {
     }
   }
 
-  /**
-   * Force projects to declare which install profile to use.
-   *
-   * I.e. return 'some_profile'.
-   */
-  function getDrupalProfile() {
-    $profile = getenv('SHEPHERD_INSTALL_PROFILE');
-    if (empty($profile)) {
-      echo "Install profile environment variable is not set.\n";
+    /**
+     * Force projects to declare which install profile to use.
+     *
+     * I.e. return 'some_profile'.
+     */
+    function getDrupalProfile() {
+      $profile = getenv('SHEPHERD_INSTALL_PROFILE');
+      if (empty($profile)) {
+        echo "Install profile environment variable is not set.\n";
+        exit(1);
+      }
+      return $profile;
     }
-  }
 
   /**
    * Returns known configuration from environment variables.

--- a/RoboFileBase.php
+++ b/RoboFileBase.php
@@ -56,10 +56,10 @@ abstract class RoboFileBase extends \Robo\Tasks {
      *
      * I.e. return 'some_profile'.
      */
-    function getDrupalProfile() {
+    protected function getDrupalProfile() {
       $profile = getenv('SHEPHERD_INSTALL_PROFILE');
       if (empty($profile)) {
-        echo "Install profile environment variable is not set.\n";
+        $this->say("Install profile environment variable is not set.\n");
         exit(1);
       }
       return $profile;

--- a/RoboFileBase.php
+++ b/RoboFileBase.php
@@ -56,7 +56,12 @@ abstract class RoboFileBase extends \Robo\Tasks {
    *
    * I.e. return 'some_profile'.
    */
-  protected abstract function getDrupalProfile();
+  function getDrupalProfile() {
+    $profile = getenv('SHEPHERD_INSTALL_PROFILE');
+    if (empty($profile)) {
+      echo "Install profile environment variable is not set.\n";
+    }
+  }
 
   /**
    * Returns known configuration from environment variables.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       PUBLIC_DIR: web/sites/default/files
       HASH_SALT: random-hash
       CONFIG_SYNC_DIRECTORY: /shared/private/random-hash/sync
+      SHEPHERD_INSTALL_PROFILE: standard
     volumes:
       - .:/code
       - shared:/shared


### PR DESCRIPTION
Bad naming, but has come out of that other MR - https://github.com/universityofadelaide/shepherd/pull/39 - which now depends on this MR.

Basically, this changes to using an env var instead of the RoboFile.php abstract function for the installation profile setting.