### PR TITLE
Support more middleware environments

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -157,6 +157,25 @@ class Handler
                 "    \$settings['container_yamls'][] = 'modules/contrib/redis/example.services.yml';\n" .
                 "  }\n" .
                 "}\n" .
+<<<<<<< Updated upstream
+=======
+                "\$settings['ua_middleware_service'] = array(\n" .
+                "   'environment' => array(\n" .
+                "       'DEV' => array(\n" .
+                "           'password' => getenv('UA_MIDDLEWARE_SERVICE_DEV_PASSWORD') ? file_get_contents(getenv('UA_MIDDLEWARE_SERVICE_DEV_PASSWORD'))\n" .
+                "        ),\n" .
+                "       'SIT' => array(\n" .
+                "           'password' => getenv('UA_MIDDLEWARE_SERVICE_SIT_PASSWORD') ? file_get_contents(getenv('UA_MIDDLEWARE_SERVICE_SIT_PASSWORD'))\n" .
+                "        ),\n" .
+                "       'UAT' => array(\n" .
+                "           'password' => getenv('UA_MIDDLEWARE_SERVICE_UAT_PASSWORD') ? file_get_contents(getenv('UA_MIDDLEWARE_SERVICE_UAT_PASSWORD'))\n" .
+                "        ),\n" .
+                "       'PRD' => array(\n" .
+                "           'password' => getenv('UA_MIDDLEWARE_SERVICE_PRD_PASSWORD') ? file_get_contents(getenv('UA_MIDDLEWARE_SERVICE_PRD_PASSWORD'))\n" .
+                "        ),\n" .
+                "   );\n" .
+                ");\n" .     
+>>>>>>> Stashed changes
                 "/**\n * END SHEPHERD CONFIG\n */\n" .
                 "\n" .
                 "/**\n * START LOCAL CONFIG\n */\n" .

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -159,7 +159,8 @@ class Handler
                 "}\n" .
                 "if (getenv('UA_MW_SECRET_PATH')) {\n" .
                 "   \$settings['ua_middleware_service'] = []; \n" .
-                "   foreach( glob(getenv('UA_MW_SECRET_PATH') . 'UA_MW_*') as \$secret) {\n" .
+                "   // Glob the secret path for secrets, that match pattern \n" .
+                "   foreach( glob( rtrim(getenv('UA_MW_SECRET_PATH'),DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'UA_MW_*') as \$secret) {\n" .
                 "    \$settings['ua_middleware_service'][pathinfo(\$secret)['filename']] = file_get_contents(\$secret);\n" .
                 "   }\n" .    
                 "}\n" .     

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -157,22 +157,12 @@ class Handler
                 "    \$settings['container_yamls'][] = 'modules/contrib/redis/example.services.yml';\n" .
                 "  }\n" .
                 "}\n" .
-                "\$settings['ua_middleware_service'] = array(\n" .
-                "   'environment' => array(\n" .
-                "       'DEV' => array(\n" .
-                "           'password' => getenv('UA_MIDDLEWARE_SERVICE_DEV_PASSWORD') ? file_get_contents(getenv('UA_MIDDLEWARE_SERVICE_DEV_PASSWORD'))\n" .
-                "        ),\n" .
-                "       'SIT' => array(\n" .
-                "           'password' => getenv('UA_MIDDLEWARE_SERVICE_SIT_PASSWORD') ? file_get_contents(getenv('UA_MIDDLEWARE_SERVICE_SIT_PASSWORD'))\n" .
-                "        ),\n" .
-                "       'UAT' => array(\n" .
-                "           'password' => getenv('UA_MIDDLEWARE_SERVICE_UAT_PASSWORD') ? file_get_contents(getenv('UA_MIDDLEWARE_SERVICE_UAT_PASSWORD'))\n" .
-                "        ),\n" .
-                "       'PRD' => array(\n" .
-                "           'password' => getenv('UA_MIDDLEWARE_SERVICE_PRD_PASSWORD') ? file_get_contents(getenv('UA_MIDDLEWARE_SERVICE_PRD_PASSWORD'))\n" .
-                "        ),\n" .
-                "   );\n" .
-                ");\n" .     
+                "if (getenv('UA_MW_SECRET_PATH')) {\n" .
+                "   \$settings['ua_middleware_service'] = []; \n" .
+                "   foreach( glob(getenv('UA_MW_SECRET_PATH') . 'UA_MW_*') as \$secret) {\n" .
+                "    \$settings['ua_middleware_service'][pathinfo(\$secret)['filename']] = file_get_contents(\$secret);\n" .
+                "   }\n" .    
+                "}\n" .     
                 "/**\n * END SHEPHERD CONFIG\n */\n" .
                 "\n" .
                 "/**\n * START LOCAL CONFIG\n */\n" .

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -157,8 +157,6 @@ class Handler
                 "    \$settings['container_yamls'][] = 'modules/contrib/redis/example.services.yml';\n" .
                 "  }\n" .
                 "}\n" .
-<<<<<<< Updated upstream
-=======
                 "\$settings['ua_middleware_service'] = array(\n" .
                 "   'environment' => array(\n" .
                 "       'DEV' => array(\n" .
@@ -175,7 +173,6 @@ class Handler
                 "        ),\n" .
                 "   );\n" .
                 ");\n" .     
->>>>>>> Stashed changes
                 "/**\n * END SHEPHERD CONFIG\n */\n" .
                 "\n" .
                 "/**\n * START LOCAL CONFIG\n */\n" .


### PR DESCRIPTION
Add support to specify different secrets for different middleware environments. 
The environment variable is not the secret, its the path to it. 
![2aylow](https://user-images.githubusercontent.com/2253412/40521053-c2173b34-6008-11e8-932b-a21ee3273515.jpg)

In shepherd you would specify the path to the secret.
In openshift you would create a secret and then mount it to your deployment config. 
