### PR TITLE
The upstream project creation tool no longer creates services.yml, don't try and update permissions on it.

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -162,8 +162,8 @@ class Handler
                 "   // Glob the secret path for secrets, that match pattern \n" .
                 "   foreach( glob( rtrim(getenv('UA_MW_SECRET_PATH'),DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'UA_MW_*') as \$secret) {\n" .
                 "    \$settings['ua_middleware_service'][pathinfo(\$secret)['filename']] = file_get_contents(\$secret);\n" .
-                "   }\n" .    
-                "}\n" .     
+                "   }\n" .
+                "}\n" .
                 "/**\n * END SHEPHERD CONFIG\n */\n" .
                 "\n" .
                 "/**\n * START LOCAL CONFIG\n */\n" .
@@ -187,7 +187,6 @@ class Handler
     public function removeWritePermissions()
     {
         $root = $this->getDrupalRootPath();
-        $this->filesystem->chmod($root . '/sites/default/services.yml', 0444);
         $this->filesystem->chmod($root . '/sites/default/settings.php', 0444);
         $this->filesystem->chmod($root . '/sites/default', 0555);
     }


### PR DESCRIPTION
Found this issue when updating my equivalent of https://github.com/universityofadelaide/shepherd-drupal-project
The drupal-composer/drupal-project tool no longer creates the services.yml as per this MR
https://github.com/drupal-composer/drupal-project/pull/265
Having this try and change permissions on a non-existant file makes the setup of the project die.
