### PR TITLE
Resolves shared folder not being mounted into the web container.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.2'
+version: '3'
 services:
   web:
     image: uofa/apache2-php7-dev:shepherd
@@ -23,15 +23,9 @@ services:
       CONFIG_SYNC_DIRECTORY: /shared/private/random-hash/sync
       SHEPHERD_INSTALL_PROFILE: standard
     volumes:
-      - type: bind
-        source: .
-        target: /code
-      - type: bind
-        source: ./shared
-        target: /shared
-      - type: bind
-        source: ${HOST_SSH_AUTH_SOCK_DIR}
-        target: /ssh
+      - .:/code
+      - ./shared:/shared
+      - ${HOST_SSH_AUTH_SOCK_DIR}:/ssh
   db:
     image: mariadb
     environment:


### PR DESCRIPTION
See https://docs.docker.com/compose/compose-file/#long-syntax-3

To test try on a Drupal project:
```
touch shared/public/meh.txt
./dsh
ls /shared/public
# empty folder

# quit out of the container
./dsh purge
# apply the docker-compose change from this PR.
./dsh
ls /shared/public
# meh.txt is present
```