### PR TITLE
Use Docker for Mac's NFS support

### DIFF
--- a/docker-compose.osx.yml
+++ b/docker-compose.osx.yml
@@ -27,7 +27,7 @@ services:
       XDEBUG_CONFIG: "remote_host=docker.for.mac.localhost"
       PHP_IDE_CONFIG: serverName=localhost
     volumes:
-      - .:/code
+      - nfsmount:/code
       - ./shared:/shared
       - $HOME/.ssh/id_rsa:/root/.ssh/id_rsa
 
@@ -53,3 +53,11 @@ services:
   redis:
     image: redis:alpine
     network_mode: service:web
+
+volumes:
+  nfsmount:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":${PWD}"

--- a/dsh
+++ b/dsh
@@ -110,6 +110,8 @@ dsh_pull() {
 
 # Command: ./dsh nfs
 # Sets up NFS integration for OSX.
+NFS_FILE=/etc/exports
+NFS_LINE="/Users -alldirs -mapall=$(id -u):$(id -g) localhost"
 dsh_setup_nfs() {
   if [ ${HOST_TYPE} != "mac" ]; then
     echo "This script is OSX-only. Please do not run it on any other Unix."
@@ -154,19 +156,15 @@ dsh_setup_nfs() {
   osascript -e 'quit app "Docker"'
 
   echo "== Resetting folder permissions..."
-  U=`id -u`
-  G=`id -g`
-  sudo chown -R "$U":"$G" .
+  sudo chown -R "$(id -u)":"$(id -g)" .
 
   echo "== Setting up nfs..."
-  LINE="/Users -alldirs -mapall=$U:$G localhost"
-  FILE=/etc/exports
-  sudo cp /dev/null $FILE
-  grep -qF -- "$LINE" "$FILE" || sudo echo "$LINE" | sudo tee -a $FILE > /dev/null
+  sudo cp /dev/null "$NFS_FILE"
+  grep -qF -- "$NFS_LINE" "$NFS_FILE" || sudo echo "$NFS_LINE" | sudo tee -a "$NFS_FILE" > /dev/null
 
   LINE="nfs.server.mount.require_resv_port = 0"
   FILE=/etc/nfs.conf
-  grep -qF -- "$LINE" "$FILE" || sudo echo "$LINE" | sudo tee -a $FILE > /dev/null
+  grep -qF -- "$LINE" "$FILE" || sudo echo "$LINE" | sudo tee -a "$FILE" > /dev/null
 
   echo "== Restarting nfsd..."
   sudo nfsd restart
@@ -178,6 +176,26 @@ dsh_setup_nfs() {
 
   echo ""
   echo "SUCCESS! Now go run your containers 🐳"
+}
+
+# Command: ./dsh rnfs
+# Removes nfs setup.
+dsh_remove_nfs() {
+  if [ ${HOST_TYPE} != "mac" ]; then
+    echo "This script is OSX-only. Please do not run it on any other Unix."
+    exit 1
+  fi
+
+  if [[ $EUID -eq 0 ]]; then
+    echo "This script must NOT be run with sudo/root. Please re-run without sudo." 1>&2
+    exit 1
+  fi
+
+  echo "== Removing nfsd exports..."
+  sudo sed -i '' "/$(echo "$NFS_LINE" | sed 's/\//\\\//g')/d" ${NFS_FILE}
+  echo "== Restarting nfsd..."
+  sudo nfsd restart
+  echo "== Done"
 }
 
 dsh_help() {
@@ -206,8 +224,11 @@ case ${COMMAND} in
   l*)
     dsh_logs
     ;;
-  nf*)
+  nfs)
     dsh_setup_nfs
+    ;;
+  rnfs)
+    dsh_remove_nfs
     ;;
   pul*)
     dsh_pull

--- a/dsh
+++ b/dsh
@@ -108,6 +108,78 @@ dsh_pull() {
   docker-compose -f ${DOCKER_COMPOSE_FILE} pull
 }
 
+# Command: ./dsh nfs
+# Sets up NFS integration for OSX.
+dsh_setup_nfs() {
+  if [ ${HOST_TYPE} != "mac" ]; then
+    echo "This script is OSX-only. Please do not run it on any other Unix."
+    exit 1
+  fi
+
+  if [[ $EUID -eq 0 ]]; then
+    echo "This script must NOT be run with sudo/root. Please re-run without sudo." 1>&2
+    exit 1
+  fi
+
+  echo ""
+  echo " +-----------------------------+"
+  echo " | Setup native NFS for Docker |"
+  echo " +-----------------------------+"
+  echo ""
+
+  echo "WARNING: This script will shut down running containers."
+  echo ""
+  echo -n "Do you wish to proceed? [y]: "
+  read decision
+
+  if [ "$decision" != "y" ]; then
+    echo "Exiting. No changes made."
+    exit 1
+  fi
+
+  echo ""
+
+  if ! docker ps > /dev/null 2>&1 ; then
+    echo "== Waiting for docker to start..."
+  fi
+
+  open -a Docker
+
+  while ! docker ps > /dev/null 2>&1 ; do sleep 2; done
+
+  echo "== Stopping running docker containers..."
+  docker-compose -f ${DOCKER_COMPOSE_FILE} down > /dev/null 2>&1
+  docker volume prune -f > /dev/null
+
+  osascript -e 'quit app "Docker"'
+
+  echo "== Resetting folder permissions..."
+  U=`id -u`
+  G=`id -g`
+  sudo chown -R "$U":"$G" .
+
+  echo "== Setting up nfs..."
+  LINE="/Users -alldirs -mapall=$U:$G localhost"
+  FILE=/etc/exports
+  sudo cp /dev/null $FILE
+  grep -qF -- "$LINE" "$FILE" || sudo echo "$LINE" | sudo tee -a $FILE > /dev/null
+
+  LINE="nfs.server.mount.require_resv_port = 0"
+  FILE=/etc/nfs.conf
+  grep -qF -- "$LINE" "$FILE" || sudo echo "$LINE" | sudo tee -a $FILE > /dev/null
+
+  echo "== Restarting nfsd..."
+  sudo nfsd restart
+
+  echo "== Restarting docker..."
+  open -a Docker
+
+  while ! docker ps > /dev/null 2>&1 ; do sleep 2; done
+
+  echo ""
+  echo "SUCCESS! Now go run your containers 🐳"
+}
+
 dsh_help() {
   printf "\nUsage: dsh COMMAND\n\n
 Commands:\n
@@ -133,6 +205,9 @@ case ${COMMAND} in
     ;;
   l*)
     dsh_logs
+    ;;
+  nf*)
+    dsh_setup_nfs
     ;;
   pul*)
     dsh_pull


### PR DESCRIPTION
Based on https://medium.com/@sean.handley/how-to-set-up-docker-for-mac-with-native-nfs-145151458adc

We get huge benefits from this:

Unit test current baseline: 25 seconds (in web container)
Robo build baseline: 7 minutes 25 seconds

Unit test with NFS: 6.3 seconds (400% speed up)
Robo build with NFS: 3 minutes 5 seconds (>200% speed up)

The `./dsh nfs` script is a one off script to run to set up NFSD configuration.