### PR TITLE
Add no-interaction flag to composer install

### DIFF
--- a/RoboFileBase.php
+++ b/RoboFileBase.php
@@ -183,7 +183,7 @@ abstract class RoboFileBase extends \Robo\Tasks {
    *   Additional flags to pass to the composer install command.
    */
   public function buildMake($flags = '') {
-    $successful = $this->_exec("$this->composer_bin --no-progress $flags install")->wasSuccessful();
+    $successful = $this->_exec("$this->composer_bin --no-progress --no-interaction $flags install")->wasSuccessful();
 
     $this->checkFail($successful, "Composer install failed.");
   }


### PR DESCRIPTION
To avoid issues with builds stopping from this:

```
 [Exec] Running composer --no-progress  install
Do not run Composer as root/super user! See https://getcomposer.org/root for details
Gathering patches for root package.
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Package operations: 0 installs, 5 updates, 0 removals
Gathering patches for root package.
Gathering patches for dependencies. This might take a minute.
  - Updating drupal/linkit (5.0.0-beta7 => dev-5.x 4b16c8e):     The package has modified files:
    M src/Plugin/Filter/LinkitFilter.php
    M src/Plugin/Linkit/Matcher/EntityMatcher.php
    Discard changes [y,n,v,d,s,?]? ^C
```