### PR TITLE
Simplify using docker-compose commands.

### DIFF
--- a/dsh
+++ b/dsh
@@ -56,7 +56,7 @@ Connecting via ./dsh shell and running robo build is a common next step."
 # Command: ./dsh shell
 # Connects a shell to the web image as the current user.
 dsh_shell() {
-  if ! docker ps | grep "\s${PROJECT}_web_1" > /dev/null; then
+  if docker-compose -f ${DOCKER_COMPOSE_FILE} ps --filter "status=stopped" --services | grep web > /dev/null; then
     notice "Project not running, starting."
     dsh_start
   fi
@@ -83,9 +83,7 @@ dsh_purge() {
 # Command: ./dsh status
 # Shows status information about project containers.
 dsh_status() {
-  if ! docker ps | grep "\s${PROJECT}_"; then
-    notice "${PROJECT} not running."
-  fi
+  docker-compose -f ${DOCKER_COMPOSE_FILE} ps
 }
 
 # Command: ./dsh logs


### PR DESCRIPTION
Latest docker compose names containers using a random string at the end, so we should just let docker-compose to manage container names for us.

- Check for web container running using `docker-compose ps`.
- Status command can just show all containers defined in docker-compose.