### PR TITLE
Updating scaffold to support s2i decorated dev and infinispan for memcache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,59 @@
+FROM uofa/s2i-shepherd-drupal
+
+ARG USER_ID
+ARG GROUP_ID
+
+# Need to switch from www-data to root to do the change of uid
+USER 0:0
+
+RUN if [ ${USER_ID:-0} -ne 0 ] && [ ${GROUP_ID:-0} -ne 0 ]; then \
+    userdel -f www-data && \
+    if getent group www-data ; then groupdel www-data; fi && \
+    groupadd -g ${GROUP_ID} www-data && \
+    useradd -l -u ${USER_ID} -g www-data www-data && \
+    install -d -m 0755 -o www-data -g www-data /home/www-data && \
+    chown --changes --no-dereference --recursive \
+          --from=33 ${USER_ID}:${GROUP_ID} \
+        /var/www \
+        /run/lock \
+        /var/run/apache2 \
+        /var/log/apache2 \
+        /var/lock/apache2 \
+        /code \
+        /shared \
+  ;fi
+
+# Add the chromedriver repo using php, no wget or curl here.
+RUN php -n -r 'echo file_get_contents("https://dl-ssl.google.com/linux/linux_signing_key.pub");' | apt-key add - \
+&& echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google-chrome.list
+
+# Upgrade all currently installed packages and install additional packages.
+RUN apt-get update \
+&& apt-get -y install php-sqlite3 php-xdebug php7.2-cli git wget sudo unzip libnotify-bin google-chrome-stable vim \
+&& sed -ri 's/^zend.assertions\s*=\s*-1/zend.assertions = 1/g' /etc/php/7.2/cli/php.ini \
+&& sed -i 's/^\(allow_url_fopen\s*=\s*\).*$/\1on/g' /etc/php/7.2/mods-available/php_custom.ini \
+&& CHROME_DRIVER_VERSION=$(php -n -r 'echo file_get_contents("https://chromedriver.storage.googleapis.com/LATEST_RELEASE");') \
+&& wget https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip \
+&& unzip -o chromedriver_linux64.zip -d /usr/local/bin \
+&& rm -f chromedriver_linux64.zip \
+&& chmod +x /usr/local/bin/chromedriver \
+&& apt-get -y autoremove && apt-get -y autoclean && apt-get clean && rm -rf /var/lib/apt/lists /tmp/* /var/tmp/*
+
+# Install Composer.
+RUN wget -q https://getcomposer.org/installer -O - | php -d allow_url_fopen=On -- --install-dir=/usr/local/bin --filename=composer
+
+RUN echo "zend_extension=xdebug.so" > /etc/php/7.2/mods-available/xdebug.ini \
+&& echo "xdebug.max_nesting_level=500" >> /etc/php/7.2/mods-available/xdebug.ini \
+&& echo "xdebug.remote_enable=1" >> /etc/php/7.2/mods-available/xdebug.ini \
+&& echo "xdebug.remote_handler=dbgp" >> /etc/php/7.2/mods-available/xdebug.ini \
+&& echo "xdebug.remote_mode=req" >> /etc/php/7.2/mods-available/xdebug.ini \
+&& echo "xdebug.remote_port=9000" >> /etc/php/7.2/mods-available/xdebug.ini \
+&& echo "xdebug.remote_connect_back=1" >> /etc/php/7.2/mods-available/xdebug.ini \
+&& echo "xdebug.idekey=PHPSTORM" >> /etc/php/7.2/mods-available/xdebug.ini
+
+RUN echo "www-data ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/www-data
+
+# Enable xdebug.
+RUN phpenmod -v ALL -s ALL xdebug
+
+USER www-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ USER 0:0
 RUN \
 if [ ${USER_ID:-0} -ne 0 ] && [ ${GROUP_ID:-0} -ne 0 ]; then \
     userdel -f www-data \
-    && groupdel -f dialout \
+    && groupdel dialout \
     && if getent group www-data ; then groupdel www-data; fi \
     && groupadd -g ${GROUP_ID} www-data \
     && useradd -l -u ${USER_ID} -g www-data www-data \

--- a/docker-compose.linux.yml
+++ b/docker-compose.linux.yml
@@ -11,6 +11,8 @@ services:
     # Chrome webdriver requires this - used for tests.
     privileged: true
     hostname: ${PROJECT}
+    ports:
+      - "80:8080"
     environment:
       CONFIG_SYNC_DIRECTORY: /shared/private/random-hash/sync
       DATABASE_HOST: db
@@ -69,6 +71,13 @@ services:
 
   memcached:
     image: jboss/infinispan-server:9.4.11.Final
+    ports:
+      - "9990:9990"
+    environment:
+      APP_USER: user
+      APP_PASS: pass
+      MGMT_USER: admin
+      MGMT_PASS: admin
     entrypoint:
       - docker-entrypoint.sh
       - -c

--- a/docker-compose.linux.yml
+++ b/docker-compose.linux.yml
@@ -2,9 +2,9 @@ version: '3'
 services:
   web:
     image: uofa/apache2-php7-dev:foundation
-    # This makes the container run on the same network stack as your
-    # workstation. Meaning that you can interact on "localhost".
-    network_mode: host
+    # Chrome webdriver requires this - used for tests.
+    privileged: true
+    hostname: ${PROJECT}
     environment:
       SITE_TITLE: WCMS D8
       SITE_MAIL: site@example.com
@@ -18,14 +18,22 @@ services:
       SHEPHERD_URL: http://shepherd.test
       SHEPHERD_TOKEN: super-secret-token
       SHEPHERD_INSTALL_PROFILE: ua
-      REDIS_ENABLED: 1
+      DATABASE_HOST: db
+      REDIS_HOST: redis
+      MEMCACHE_ENABLED: 1
+      MEMCACHE_HOST: memcache
       SHEPHERD_SECRET_PATH: /code/private
-      XDEBUG_CONFIG: "remote_host=127.0.0.1"
-      PHP_IDE_CONFIG: serverName=localhost
+      XDEBUG_CONFIG: "remote_host=172.17.0.1"
+      PHP_IDE_CONFIG: serverName=${PROJECT}.${DOMAIN}
+      VIRTUAL_HOST: ${PROJECT}.${DOMAIN}
+      # Do not define this as '/' or apache2 will give strange behaviour
+      # WEB_PATH: /
     volumes:
       - .:/code
       - ./shared:/shared
-      - $HOME/.ssh/id_rsa:/root/.ssh/id_rsa
+      - ${HOST_SSH_AUTH_SOCK_DIR}:/ssh
+    networks:
+      - default
 
   db:
     image: mariadb
@@ -35,15 +43,25 @@ services:
       MYSQL_USER: user
       MYSQL_PASSWORD: password
       MYSQL_ROOT_PASSWORD: super-secret-password
+    networks:
+      - default
 
   mail:
     image: mailhog/mailhog
-    network_mode: host
+    environment:
+      VIRTUAL_HOST: mail.${PROJECT}.${DOMAIN}
+    networks:
+      - default
 
   redis:
     image: redis:alpine
-    network_mode: host
+    networks:
+      - default
 
-  memcached:
-    image: memcached:alpine
-    network_mode: host
+  memcache:
+    image: jboss/infinispan-server:9.4.11.Final
+    # Custom command to pass in the mode we want
+    command: |
+      docker-entrypoint.sh standalone-memcached
+    networks:
+      - default

--- a/docker-compose.linux.yml
+++ b/docker-compose.linux.yml
@@ -12,28 +12,27 @@ services:
     privileged: true
     hostname: ${PROJECT}
     environment:
+      CONFIG_SYNC_DIRECTORY: /shared/private/random-hash/sync
+      DATABASE_HOST: db
+      DATABASE_USER: user
+      DATABASE_PASSWORD: password
+      HASH_SALT: random-hash
+      PHP_IDE_CONFIG: serverName=${PROJECT:-shop8}.${DOMAIN:-172.17.0.1.xip.io}
+      PUBLIC_DIR: /shared/public
+      REDIS_ENABLED: 1
+      REDIS_HOST: redis
+      SHEPHERD_SITE_ID: 2
+      SHEPHERD_INSTALL_PROFILE: ua
+      SHEPHERD_SECRET_PATH: /code/private
+      SHEPHERD_TOKEN: super-secret-token
+      SHEPHERD_URL: http://shepherd.test
       SITE_TITLE: WCMS D8
       SITE_MAIL: site@example.com
       SITE_ADMIN_EMAIL: admin@example.com
       SITE_ADMIN_USERNAME: admin
       SITE_ADMIN_PASSWORD: password
-      PUBLIC_DIR: /shared/public
-      HASH_SALT: random-hash
-      CONFIG_SYNC_DIRECTORY: /shared/private/random-hash/sync
-      SHEPHERD_SITE_ID: 2
-      SHEPHERD_URL: http://shepherd.test
-      SHEPHERD_TOKEN: super-secret-token
-      SHEPHERD_INSTALL_PROFILE: ua
-      DATABASE_HOST: db
-      REDIS_HOST: redis
-      MEMCACHE_ENABLED: 1
-      MEMCACHE_HOST: memcache
-      SHEPHERD_SECRET_PATH: /code/private
+      VIRTUAL_HOST: ${PROJECT:-shop8}.${DOMAIN:-172.17.0.1.xip.io}
       XDEBUG_CONFIG: "remote_host=172.17.0.1"
-      PHP_IDE_CONFIG: serverName=${PROJECT}.${DOMAIN}
-      VIRTUAL_HOST: ${PROJECT}.${DOMAIN}
-      # Do not define this as '/' or apache2 will give strange behaviour
-      # WEB_PATH: /
     volumes:
       - .:/code
       - ./shared:/shared
@@ -53,23 +52,10 @@ services:
 
   mail:
     image: mailhog/mailhog
-    environment:
-      VIRTUAL_HOST: mail.${PROJECT}.${DOMAIN}
     networks:
       - default
 
   redis:
     image: redis:alpine
-    networks:
-      - default
-
-  memcached:
-    image: jboss/infinispan-server:9.4.11.Final
-    entrypoint:
-      - docker-entrypoint.sh
-      - -c
-      - standalone-memcached.xml
-    volumes:
-      - ./standalone-memcached.xml:/opt/jboss/infinispan-server/standalone/configuration/standalone-memcached.xml
     networks:
       - default

--- a/docker-compose.linux.yml
+++ b/docker-compose.linux.yml
@@ -17,9 +17,11 @@ services:
       DATABASE_USER: user
       DATABASE_PASSWORD: password
       HASH_SALT: random-hash
-      PHP_IDE_CONFIG: serverName=${PROJECT:-shop8}.${DOMAIN:-172.17.0.1.xip.io}
+      MEMCACHE_ENABLED: 1
+      MEMCACHE_HOST: memcached
+      PHP_IDE_CONFIG: serverName=${PROJECT}.${DOMAIN}
       PUBLIC_DIR: /shared/public
-      REDIS_ENABLED: 1
+      REDIS_ENABLED: 0
       REDIS_HOST: redis
       SHEPHERD_SITE_ID: 2
       SHEPHERD_INSTALL_PROFILE: ua
@@ -31,7 +33,10 @@ services:
       SITE_ADMIN_EMAIL: admin@example.com
       SITE_ADMIN_USERNAME: admin
       SITE_ADMIN_PASSWORD: password
-      VIRTUAL_HOST: ${PROJECT:-shop8}.${DOMAIN:-172.17.0.1.xip.io}
+      VIRTUAL_HOST: ${PROJECT}.${DOMAIN}
+      # Do not define this as '/' or apache2 will give strange behaviour, to test locally,
+      # change to the web directory and create a symlink to the subpath name eg ln -s . subpath
+      # WEB_PATH: /subpath
       XDEBUG_CONFIG: "remote_host=172.17.0.1"
     volumes:
       - .:/code
@@ -52,6 +57,8 @@ services:
 
   mail:
     image: mailhog/mailhog
+    environment:
+      VIRTUAL_HOST: mail.${PROJECT}.${DOMAIN}
     networks:
       - default
 

--- a/docker-compose.linux.yml
+++ b/docker-compose.linux.yml
@@ -43,3 +43,7 @@ services:
   redis:
     image: redis:alpine
     network_mode: host
+
+  memcached:
+    image: memcached:alpine
+    network_mode: host

--- a/docker-compose.linux.yml
+++ b/docker-compose.linux.yml
@@ -59,3 +59,14 @@ services:
     image: redis:alpine
     networks:
       - default
+
+  memcached:
+    image: jboss/infinispan-server:9.4.11.Final
+    entrypoint:
+      - docker-entrypoint.sh
+      - -c
+      - standalone-memcached.xml
+    volumes:
+      - ./standalone-memcached.xml:/opt/jboss/infinispan-server/standalone/configuration/standalone-memcached.xml
+    networks:
+      - default

--- a/docker-compose.linux.yml
+++ b/docker-compose.linux.yml
@@ -1,7 +1,13 @@
 version: '3'
 services:
   web:
-    image: uofa/apache2-php7-dev:foundation
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        USER_ID: ${USER_ID:-1000}
+        GROUP_ID: ${GROUP_ID:-1000}
+    image: uofa/s2i-shepherd-drupal-dev
     # Chrome webdriver requires this - used for tests.
     privileged: true
     hostname: ${PROJECT}
@@ -31,13 +37,12 @@ services:
     volumes:
       - .:/code
       - ./shared:/shared
-      - ${HOST_SSH_AUTH_SOCK_DIR}:/ssh
+      - ${XDG_RUNTIME_DIR}/keyring:/ssh
     networks:
       - default
 
   db:
     image: mariadb
-    network_mode: host
     environment:
       MYSQL_DATABASE: drupal
       MYSQL_USER: user
@@ -58,10 +63,13 @@ services:
     networks:
       - default
 
-  memcache:
+  memcached:
     image: jboss/infinispan-server:9.4.11.Final
-    # Custom command to pass in the mode we want
-    command: |
-      docker-entrypoint.sh standalone-memcached
+    entrypoint:
+      - docker-entrypoint.sh
+      - -c
+      - standalone-memcached.xml
+    volumes:
+      - ./standalone-memcached.xml:/opt/jboss/infinispan-server/standalone/configuration/standalone-memcached.xml
     networks:
       - default

--- a/docker-compose.osx.yml
+++ b/docker-compose.osx.yml
@@ -54,6 +54,10 @@ services:
     image: redis:alpine
     network_mode: service:web
 
+  memcached:
+    image: memcached:alpine
+    network_mode: service:web
+
 volumes:
   nfsmount:
     driver: local

--- a/docker-compose.osx.yml
+++ b/docker-compose.osx.yml
@@ -12,26 +12,26 @@ services:
     # We have to declare them here because these "sidecar" services are sharing
     # THIS containers network stack.
     ports:
-      - "80:80"
+      - "80:8080"
       - "3306:3306"
       - "8025:8025"
     environment:
+      CONFIG_SYNC_DIRECTORY: /shared/private/random-hash/sync
+      HASH_SALT: random-hash
+      PUBLIC_DIR: /shared/public
+      REDIS_ENABLED: 1
+      SHEPHERD_INSTALL_PROFILE: ua
+      SHEPHERD_SITE_ID: 2
+      SHEPHERD_SECRET_PATH: /code/private
+      SHEPHERD_TOKEN: super-secret-token
+      SHEPHERD_URL: http://shepherd.test
       SITE_TITLE: WCMS D8
       SITE_MAIL: site@example.com
       SITE_ADMIN_EMAIL: admin@example.com
       SITE_ADMIN_USERNAME: admin
       SITE_ADMIN_PASSWORD: password
-      PUBLIC_DIR: /shared/public
-      HASH_SALT: random-hash
-      CONFIG_SYNC_DIRECTORY: /shared/private/random-hash/sync
-      SHEPHERD_SITE_ID: 2
-      SHEPHERD_URL: http://shepherd.test
-      SHEPHERD_TOKEN: super-secret-token
-      SHEPHERD_INSTALL_PROFILE: ua
-      REDIS_ENABLED: 1
-      SHEPHERD_SECRET_PATH: /code/private
-      XDEBUG_CONFIG: "remote_host=docker.for.mac.localhost"
       PHP_IDE_CONFIG: serverName=localhost
+      XDEBUG_CONFIG: "remote_host=docker.for.mac.localhost"
     volumes:
       - nfsmount:/code
       - ./shared:/shared
@@ -58,16 +58,6 @@ services:
 
   redis:
     image: redis:alpine
-    network_mode: service:web
-
-  memcached:
-    image: jboss/infinispan-server:9.4.11.Final
-    entrypoint:
-      - docker-entrypoint.sh
-      - -c
-      - standalone-memcached.xml
-    volumes:
-      - ./standalone-memcached.xml:/opt/jboss/infinispan-server/standalone/configuration/standalone-memcached.xml
     network_mode: service:web
 
 volumes:

--- a/docker-compose.osx.yml
+++ b/docker-compose.osx.yml
@@ -15,6 +15,7 @@ services:
       - "80:8080"
       - "3306:3306"
       - "8025:8025"
+      - "11211:11211"
     environment:
       CONFIG_SYNC_DIRECTORY: /shared/private/random-hash/sync
       HASH_SALT: random-hash
@@ -58,6 +59,16 @@ services:
 
   redis:
     image: redis:alpine
+    network_mode: service:web
+
+  memcached:
+    image: jboss/infinispan-server:9.4.11.Final
+    entrypoint:
+      - docker-entrypoint.sh
+      - -c
+      - standalone-memcached.xml
+    volumes:
+      - ./standalone-memcached.xml:/opt/jboss/infinispan-server/standalone/configuration/standalone-memcached.xml
     network_mode: service:web
 
 volumes:

--- a/docker-compose.osx.yml
+++ b/docker-compose.osx.yml
@@ -19,8 +19,9 @@ services:
     environment:
       CONFIG_SYNC_DIRECTORY: /shared/private/random-hash/sync
       HASH_SALT: random-hash
+      MEMCACHE_ENABLED: 1
       PUBLIC_DIR: /shared/public
-      REDIS_ENABLED: 1
+      REDIS_ENABLED: 0
       SHEPHERD_INSTALL_PROFILE: ua
       SHEPHERD_SITE_ID: 2
       SHEPHERD_SECRET_PATH: /code/private

--- a/docker-compose.osx.yml
+++ b/docker-compose.osx.yml
@@ -1,7 +1,13 @@
 version: '3'
 services:
   web:
-    image: uofa/apache2-php7-dev:foundation
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        USER_ID: ${USER_ID:-1000}
+        GROUP_ID: ${GROUP_ID:-1000}
+    image: uofa/s2i-shepherd-drupal-dev
     # You will notice that we are forwarding port which do not belong to PHP.
     # We have to declare them here because these "sidecar" services are sharing
     # THIS containers network stack.
@@ -55,7 +61,13 @@ services:
     network_mode: service:web
 
   memcached:
-    image: memcached:alpine
+    image: jboss/infinispan-server:9.4.11.Final
+    entrypoint:
+      - docker-entrypoint.sh
+      - -c
+      - standalone-memcached.xml
+    volumes:
+      - ./standalone-memcached.xml:/opt/jboss/infinispan-server/standalone/configuration/standalone-memcached.xml
     network_mode: service:web
 
 volumes:

--- a/docker-compose.osx.yml
+++ b/docker-compose.osx.yml
@@ -15,6 +15,7 @@ services:
       - "80:8080"
       - "3306:3306"
       - "8025:8025"
+      - "9990:9990"
       - "11211:11211"
     environment:
       CONFIG_SYNC_DIRECTORY: /shared/private/random-hash/sync
@@ -64,6 +65,11 @@ services:
 
   memcached:
     image: jboss/infinispan-server:9.4.11.Final
+    environment:
+      APP_USER: user
+      APP_PASS: pass
+      MGMT_USER: admin
+      MGMT_PASS: admin
     entrypoint:
       - docker-entrypoint.sh
       - -c

--- a/dsh
+++ b/dsh
@@ -21,6 +21,10 @@ else
   export DOCKER_COMPOSE_FILE='docker-compose.linux.yml'
 fi
 
+# Set user variables
+USER_ID=$(id -u ${USER})
+GROUP_ID=$(id -g ${USER})
+
 # Setup some functions to output warnings.
 notice() {
   printf "\e[32;01m$1\e[39;49;00m\n"
@@ -106,7 +110,7 @@ dsh_pull() {
 # Command: ./dsh nfs
 # Sets up NFS integration for OSX.
 NFS_FILE=/etc/exports
-NFS_LINE="/Users -alldirs -mapall=$(id -u):$(id -g) localhost"
+NFS_LINE="/Users -alldirs -mapall=${USER_ID}:${GROUP_ID} localhost"
 dsh_setup_nfs() {
   if [ ${HOST_TYPE} != "mac" ]; then
     echo "This script is OSX-only. Please do not run it on any other Unix."
@@ -151,7 +155,7 @@ dsh_setup_nfs() {
   osascript -e 'quit app "Docker"'
 
   echo "== Resetting folder permissions..."
-  sudo chown -R "$(id -u)":"$(id -g)" .
+  sudo chown -R "${USER_ID}:${GROUP_ID}" .
 
   echo "== Setting up nfs..."
   sudo cp /dev/null "$NFS_FILE"

--- a/dsh
+++ b/dsh
@@ -79,6 +79,7 @@ dsh_stop() {
 # Stops project, then takes down containers and removes volumes if possible.
 dsh_purge() {
   docker-compose -f ${DOCKER_COMPOSE_FILE} down -v
+  docker rmi -f uofa/s2i-shepherd-drupal-dev
 }
 
 # Command: ./dsh status

--- a/dsh
+++ b/dsh
@@ -22,8 +22,8 @@ else
 fi
 
 # Set user variables
-USER_ID=$(id -u ${USER})
-GROUP_ID=$(id -g ${USER})
+export USER_ID=$(id -u ${USER})
+export GROUP_ID=$(id -g ${USER})
 
 # Setup some functions to output warnings.
 notice() {

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -81,10 +81,11 @@ class Handler
             [
                 'docker-compose.linux.yml',
                 'docker-compose.osx.yml',
-                'RoboFile.php',
-                'drush/config-ignore.yml',
                 'drush/config-delete.yml',
+                'drush/config-ignore.yml',
                 'phpcs.xml',
+                'RoboFile.php',
+                'standalone-memcached.xml',
             ]
         );
     }

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -86,6 +86,7 @@ class Handler
                 'phpcs.xml',
                 'RoboFile.php',
                 'standalone-memcached.xml',
+                'Dockerfile',
             ]
         );
     }

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -173,6 +173,7 @@ class Handler
             "  \$settings['cache']['bins']['bootstrap'] = 'cache.backend.chainedfast';\n" .
             "  \$settings['cache']['bins']['discovery'] = 'cache.backend.chainedfast';\n" .
             "  \$settings['cache']['bins']['config'] = 'cache.backend.chainedfast';\n\n" .
+            "  \$settings['cache_prefix']['default'] = getenv('REDIS_PREFIX') ?: 'mysite_';
             "  // If we're not installing, include the redis services.\n" .
             "  if (!isset(\$GLOBALS['install_state'])) {\n" .
             "    \$settings['cache']['default'] = 'cache.backend.redis';\n\n" .

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -177,6 +177,13 @@ class Handler
             "    \$settings['container_yamls'][] = 'modules/contrib/redis/example.services.yml';\n" .
             "  }\n" .
             "}\n" .
+            "if (getenv('MEMCACHE_ENABLED')) {\n" .
+            "  \$settings['redis']['servers'] = getenv('MEMCACHE_HOST') ?: '127.0.0.1';\n" .
+            "  // If we're not installing, include the memcache services.\n" .
+            "  if (!isset(\$GLOBALS['install_state'])) {\n" .
+            "    \$settings['cache']['default'] = 'cache.backend.memcache';\n\n" .
+            "  }\n" .
+            "}\n" .
             "if (getenv('SHEPHERD_SECRET_PATH')) {\n" .
             "  \$settings['shepherd_secrets'] = []; \n" .
             "  // Glob the secret path for secrets, that match pattern \n" .

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -178,10 +178,12 @@ class Handler
             "  }\n" .
             "}\n" .
             "if (getenv('MEMCACHE_ENABLED')) {\n" .
-            "  \$settings['redis']['servers'] = getenv('MEMCACHE_HOST') ?: '127.0.0.1';\n" .
+            "  \$settings['memcache']['servers'] = [getenv('MEMCACHE_HOST') . ':11211' => 'default'] ?: ['127.0.0.1:11211' => 'default'];\n" .
+            "  \$settings['memcache']['bins'] = ['default' => 'default'];\n" .
+            "  \$settings['memcache']['key_prefix'] = '';\n" .
             "  // If we're not installing, include the memcache services.\n" .
             "  if (!isset(\$GLOBALS['install_state'])) {\n" .
-            "    \$settings['cache']['default'] = 'cache.backend.memcache';\n\n" .
+            "    \$settings['cache']['default'] = 'cache.backend.memcache';\n" .
             "  }\n" .
             "}\n" .
             "if (getenv('SHEPHERD_SECRET_PATH')) {\n" .

--- a/standalone-memcached.xml
+++ b/standalone-memcached.xml
@@ -1,0 +1,351 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<server xmlns="urn:jboss:domain:8.0">
+    <extensions>
+        <extension module="org.infinispan.extension"/>
+        <extension module="org.infinispan.server.endpoint"/>
+        <extension module="org.jboss.as.connector"/>
+        <extension module="org.jboss.as.deployment-scanner"/>
+        <extension module="org.jboss.as.jdr"/>
+        <extension module="org.jboss.as.jmx"/>
+        <extension module="org.jboss.as.logging"/>
+        <extension module="org.jboss.as.naming"/>
+        <extension module="org.jboss.as.remoting"/>
+        <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.transactions"/>
+        <extension module="org.wildfly.extension.elytron"/>
+        <extension module="org.wildfly.extension.io"/>
+        <extension module="org.wildfly.extension.security.manager"/>
+    </extensions>
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <authentication>
+                    <local default-user="$local"/>
+                    <properties path="mgmt-users.properties" relative-to="jboss.server.config.dir"/>
+                </authentication>
+                <authorization map-groups-to-roles="false">
+                    <properties path="mgmt-groups.properties" relative-to="jboss.server.config.dir"/>
+                </authorization>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <server-identities>
+                    <ssl>
+                        <keystore path="application.keystore" relative-to="jboss.server.config.dir" keystore-password="password" alias="server" key-password="password" generate-self-signed-certificate-host="localhost"/>
+                    </ssl>
+                </server-identities>
+                <authentication>
+                    <local default-user="$local" allowed-users="*"/>
+                    <properties path="application-users.properties" relative-to="jboss.server.config.dir"/>
+                </authentication>
+                <authorization>
+                    <properties path="application-roles.properties" relative-to="jboss.server.config.dir"/>
+                </authorization>
+            </security-realm>
+        </security-realms>
+        <audit-log>
+            <formatters>
+                <json-formatter name="json-formatter"/>
+            </formatters>
+            <handlers>
+                <file-handler name="file" formatter="json-formatter" relative-to="jboss.server.data.dir" path="audit-log.log"/>
+            </handlers>
+            <logger log-boot="true" enabled="false">
+                <handlers>
+                    <handler name="file"/>
+                </handlers>
+            </logger>
+        </audit-log>
+        <management-interfaces>
+            <http-interface security-realm="ManagementRealm">
+                <http-upgrade enabled="true"/>
+                <socket-binding http="management-http"/>
+            </http-interface>
+        </management-interfaces>
+        <access-control>
+            <role-mapping>
+                <role name="SuperUser">
+                    <include>
+                        <user name="$local"/>
+                    </include>
+                </role>
+            </role-mapping>
+        </access-control>
+    </management>
+    <profile>
+        <subsystem xmlns="urn:jboss:domain:logging:6.0">
+            <console-handler name="CONSOLE">
+                <level name="INFO"/>
+                <formatter>
+                    <named-formatter name="COLOR-PATTERN"/>
+                </formatter>
+            </console-handler>
+            <periodic-rotating-file-handler name="FILE" autoflush="true">
+                <formatter>
+                    <named-formatter name="PATTERN"/>
+                </formatter>
+                <file relative-to="jboss.server.log.dir" path="server.log"/>
+                <suffix value=".yyyy-MM-dd"/>
+                <append value="true"/>
+            </periodic-rotating-file-handler>
+            <logger category="com.arjuna">
+                <level name="WARN"/>
+            </logger>
+            <logger category="org.jboss.as.config">
+                <level name="DEBUG"/>
+            </logger>
+            <logger category="sun.rmi">
+                <level name="WARN"/>
+            </logger>
+            <root-logger>
+                <level name="INFO"/>
+                <handlers>
+                    <handler name="CONSOLE"/>
+                    <handler name="FILE"/>
+                </handlers>
+            </root-logger>
+            <formatter name="PATTERN">
+                <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+            </formatter>
+            <formatter name="COLOR-PATTERN">
+                <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+            </formatter>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:deployment-scanner:2.0">
+            <deployment-scanner path="deployments" relative-to="jboss.server.base.dir" scan-interval="5000" runtime-failure-causes-rollback="${jboss.deployment.scanner.rollback.on.failure:false}"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:datasources:5.0">
+            <datasources>
+                <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
+                    <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+                    <driver>h2</driver>
+                    <security>
+                        <user-name>sa</user-name>
+                        <password>sa</password>
+                    </security>
+                </datasource>
+                <drivers>
+                    <driver name="h2" module="com.h2database.h2">
+                        <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
+                    </driver>
+                </drivers>
+            </datasources>
+        </subsystem>
+        <subsystem xmlns="urn:wildfly:elytron:4.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
+            <providers>
+                <aggregate-providers name="combined-providers">
+                    <providers name="elytron"/>
+                    <providers name="openssl"/>
+                </aggregate-providers>
+                <provider-loader name="elytron" module="org.wildfly.security.elytron"/>
+                <provider-loader name="openssl" module="org.wildfly.openssl"/>
+            </providers>
+            <audit-logging>
+                <file-audit-log name="local-audit" path="audit.log" relative-to="jboss.server.log.dir" format="JSON"/>
+            </audit-logging>
+            <security-domains>
+                <security-domain name="ApplicationDomain" default-realm="ApplicationRealm" permission-mapper="default-permission-mapper">
+                    <realm name="ApplicationRealm" role-decoder="groups-to-roles"/>
+                    <realm name="local"/>
+                </security-domain>
+                <security-domain name="ManagementDomain" default-realm="ManagementRealm" permission-mapper="default-permission-mapper">
+                    <realm name="ManagementRealm" role-decoder="groups-to-roles"/>
+                    <realm name="local" role-mapper="super-user-mapper"/>
+                </security-domain>
+            </security-domains>
+            <security-realms>
+                <identity-realm name="local" identity="$local"/>
+                <properties-realm name="ApplicationRealm">
+                    <users-properties path="application-users.properties" relative-to="jboss.server.config.dir" digest-realm-name="ApplicationRealm"/>
+                    <groups-properties path="application-roles.properties" relative-to="jboss.server.config.dir"/>
+                </properties-realm>
+                <properties-realm name="ManagementRealm">
+                    <users-properties path="mgmt-users.properties" relative-to="jboss.server.config.dir" digest-realm-name="ManagementRealm"/>
+                    <groups-properties path="mgmt-groups.properties" relative-to="jboss.server.config.dir"/>
+                </properties-realm>
+            </security-realms>
+            <mappers>
+                <simple-permission-mapper name="default-permission-mapper" mapping-mode="first">
+                    <permission-mapping>
+                        <principal name="anonymous"/>
+                        <permission-set name="default-permissions"/>
+                    </permission-mapping>
+                    <permission-mapping match-all="true">
+                        <permission-set name="login-permission"/>
+                        <permission-set name="default-permissions"/>
+                    </permission-mapping>
+                </simple-permission-mapper>
+                <constant-realm-mapper name="local" realm-name="local"/>
+                <simple-role-decoder name="groups-to-roles" attribute="groups"/>
+                <constant-role-mapper name="super-user-mapper">
+                    <role name="SuperUser"/>
+                </constant-role-mapper>
+            </mappers>
+            <permission-sets>
+                <permission-set name="login-permission">
+                    <permission class-name="org.wildfly.security.auth.permission.LoginPermission"/>
+                </permission-set>
+                <permission-set name="default-permissions"/>
+            </permission-sets>
+            <http>
+                <http-authentication-factory name="management-http-authentication" security-domain="ManagementDomain" http-server-mechanism-factory="global">
+                    <mechanism-configuration>
+                        <mechanism mechanism-name="DIGEST">
+                            <mechanism-realm realm-name="ManagementRealm"/>
+                        </mechanism>
+                    </mechanism-configuration>
+                </http-authentication-factory>
+                <provider-http-server-mechanism-factory name="global"/>
+            </http>
+            <sasl>
+                <sasl-authentication-factory name="application-sasl-authentication" sasl-server-factory="configured" security-domain="ApplicationDomain">
+                    <mechanism-configuration>
+                        <mechanism mechanism-name="JBOSS-LOCAL-USER" realm-mapper="local"/>
+                        <mechanism mechanism-name="DIGEST-MD5">
+                            <mechanism-realm realm-name="ApplicationRealm"/>
+                        </mechanism>
+                    </mechanism-configuration>
+                </sasl-authentication-factory>
+                <sasl-authentication-factory name="management-sasl-authentication" sasl-server-factory="configured" security-domain="ManagementDomain">
+                    <mechanism-configuration>
+                        <mechanism mechanism-name="JBOSS-LOCAL-USER" realm-mapper="local"/>
+                        <mechanism mechanism-name="DIGEST-MD5">
+                            <mechanism-realm realm-name="ManagementRealm"/>
+                        </mechanism>
+                    </mechanism-configuration>
+                </sasl-authentication-factory>
+                <configurable-sasl-server-factory name="configured" sasl-server-factory="elytron">
+                    <properties>
+                        <property name="wildfly.sasl.local-user.default-user" value="$local"/>
+                    </properties>
+                </configurable-sasl-server-factory>
+                <mechanism-provider-filtering-sasl-server-factory name="elytron" sasl-server-factory="global">
+                    <filters>
+                        <filter provider-name="WildFlyElytron"/>
+                    </filters>
+                </mechanism-provider-filtering-sasl-server-factory>
+                <provider-sasl-server-factory name="global"/>
+            </sasl>
+        </subsystem>
+        <subsystem xmlns="urn:infinispan:server:core:9.4" default-cache-container="local">
+            <cache-container name="local" default-cache="default" statistics="true">
+                <global-state/>
+                <local-cache name="default"/>
+                <local-cache name="namedCache"/>
+            </cache-container>
+        </subsystem>
+        <subsystem xmlns="urn:infinispan:server:endpoint:9.4">
+            <memcached-connector socket-binding="memcached" cache-container="local" cache="default"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:io:3.0">
+            <worker name="default"/>
+            <buffer-pool name="default"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jca:5.0">
+            <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
+            <bean-validation enabled="true"/>
+            <default-workmanager>
+                <short-running-threads>
+                    <core-threads count="50"/>
+                    <queue-length count="50"/>
+                    <max-threads count="50"/>
+                    <keepalive-time time="10" unit="seconds"/>
+                </short-running-threads>
+                <long-running-threads>
+                    <core-threads count="50"/>
+                    <queue-length count="50"/>
+                    <max-threads count="50"/>
+                    <keepalive-time time="10" unit="seconds"/>
+                </long-running-threads>
+            </default-workmanager>
+            <cached-connection-manager/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jdr:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+            <expose-resolved-model/>
+            <expose-expression-model/>
+            <remoting-connector/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:naming:2.0">
+            <remote-naming/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:remoting:4.0">
+            <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:security:2.0">
+            <security-domains>
+                <security-domain name="other" cache-type="default">
+                    <authentication>
+                        <login-module code="Remoting" flag="optional">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                        <login-module code="RealmDirect" flag="required">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                    </authentication>
+                </security-domain>
+                <security-domain name="jboss-web-policy" cache-type="default">
+                    <authorization>
+                        <policy-module code="Delegating" flag="required"/>
+                    </authorization>
+                </security-domain>
+                <security-domain name="jaspitest" cache-type="default">
+                    <authentication-jaspi>
+                        <login-module-stack name="dummy">
+                            <login-module code="Dummy" flag="optional"/>
+                        </login-module-stack>
+                        <auth-module code="Dummy"/>
+                    </authentication-jaspi>
+                </security-domain>
+                <security-domain name="jboss-ejb-policy" cache-type="default">
+                    <authorization>
+                        <policy-module code="Delegating" flag="required"/>
+                    </authorization>
+                </security-domain>
+            </security-domains>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:security-manager:1.0">
+            <deployment-permissions>
+                <maximum-set>
+                    <permission class="java.security.AllPermission"/>
+                </maximum-set>
+            </deployment-permissions>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:transactions:5.0">
+            <core-environment node-identifier="${jboss.tx.node.id:1}">
+                <process-id>
+                    <uuid/>
+                </process-id>
+            </core-environment>
+            <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
+            <object-store path="tx-object-store" relative-to="jboss.server.data.dir"/>
+        </subsystem>
+    </profile>
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.bind.address.management:127.0.0.1}"/>
+        </interface>
+        <interface name="public">
+            <inet-address value="${jboss.bind.address:127.0.0.1}"/>
+        </interface>
+    </interfaces>
+    <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
+        <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
+        <socket-binding name="hotrod" port="11222"/>
+        <socket-binding name="hotrod-internal" port="11223"/>
+        <socket-binding name="hotrod-multi-tenancy" port="11224"/>
+        <socket-binding name="memcached" port="11211"/>
+        <socket-binding name="rest" port="8080"/>
+        <socket-binding name="rest-multi-tenancy" port="8081"/>
+        <socket-binding name="rest-ssl" port="8443"/>
+        <socket-binding name="txn-recovery-environment" port="4712"/>
+        <socket-binding name="txn-status-manager" port="4713"/>
+        <outbound-socket-binding name="remote-store-hotrod-server">
+            <remote-destination host="remote-host" port="11222"/>
+        </outbound-socket-binding>
+        <outbound-socket-binding name="remote-store-rest-server">
+            <remote-destination host="remote-host" port="8080"/>
+        </outbound-socket-binding>
+    </socket-binding-group>
+</server>


### PR DESCRIPTION
Why
- Gives a closer to production env for developers
- Solves all known permissions issues by running apache2 as the uid of the developer
- Slight pain in that it does a build of the image locally to decorate it

Details
- Add Dockerfile that is used to decorate the public/production s2i image for development
- Adjustments to dsh and docker-compose for linux and osx to support updated image
- Cache prefix support added to settings to allow intermediate redis mitigation on Uni hosting.
- Infinispan config file added and update process for all files adjusted for new files
Requires local build of https://github.com/universityofadelaide/s2i-shepherd-drupal/pull/15 to be built first.

NOTE: Merging this to master will rebuild the production s2i and start using that automatically from dockerhub.