### PR TITLE
Rebuild dev image

### DIFF
--- a/dsh
+++ b/dsh
@@ -105,7 +105,8 @@ dsh_project() {
 # Command: ./dsh pull
 # Fetches all images used by the project.
 dsh_pull() {
-  docker-compose -f ${DOCKER_COMPOSE_FILE} pull
+  docker-compose -f ${DOCKER_COMPOSE_FILE} pull --ignore-pull-failures
+  docker-compose -f ${DOCKER_COMPOSE_FILE} build
 }
 
 # Command: ./dsh nfs


### PR DESCRIPTION
./dsh pull errored because it doesn't respect built local images - https://github.com/docker/compose/issues/3660
Also, even when the base web image updates, a build doesn't occur - maybe we don't need this because in all likelihood you would dsh purge and rebuild when you bring it up again.