### PR TITLE
Dsh pull should pull the base image before building the web container.

### DIFF
--- a/dsh
+++ b/dsh
@@ -111,6 +111,8 @@ dsh_project() {
 # Command: ./dsh pull
 # Fetches all images used by the project.
 dsh_pull() {
+  # docker-compose doesn't resolve sub-dependencies in Dockerfiles.
+  docker pull uofa/s2i-shepherd-drupal
   docker-compose -f ${DOCKER_COMPOSE_FILE} pull --ignore-pull-failures
   docker-compose -f ${DOCKER_COMPOSE_FILE} build
 }


### PR DESCRIPTION
Realised this wasn't getting pulled when I started getting strange php7.3 related errors - we're using 7.2. Finally realised this was the issue :smile: 