### PR TITLE
Feature/auto add ssh mac

### DIFF
--- a/docker-compose.osx.yml
+++ b/docker-compose.osx.yml
@@ -38,7 +38,7 @@ services:
     volumes:
       - nfsmount:/code
       - ./shared:/shared
-      - $HOME/.ssh/id_rsa:/root/.ssh/id_rsa
+      - $HOME/.ssh:/home/www-data/.ssh
 
   xdebug:
     image: nickschuch/d4m-tcp-forwarder

--- a/dsh
+++ b/dsh
@@ -65,7 +65,7 @@ dsh_shell() {
   docker-compose -f ${DOCKER_COMPOSE_FILE} exec \
    -e COLUMNS="$(tput cols)" \
    -e LINES="$(tput lines)" \
-   web ${@:-/bin/bash}
+   web ${@:-./dsh_bash}
 }
 
 # Command: ./dsh stop

--- a/dsh_bash
+++ b/dsh_bash
@@ -4,9 +4,14 @@
 # for mac (linux happens automatically)
 #
 
-if ! ssh-add -l; then
+# Try setup for linux
+export SSH_AUTH_SOCK=/ssh/ssh
+
+# Check if we have any identities, if not, try and setup
+if ! ssh-add -l > /dev/null; then
   eval $(ssh-agent -s)
   ssh-add ~/.ssh/id_rsa
 fi
 
+# Drop user into bash
 bash -l

--- a/dsh_bash
+++ b/dsh_bash
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Helper script that is run inside docker to setup ssh access
+# for mac (linux happens automatically)
+#
+
+if ! ssh-add -l; then
+  eval $(ssh-agent -s)
+  ssh-add ~/.ssh/id_rsa
+fi
+
+bash -l

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -83,6 +83,7 @@ class Handler
                 'docker-compose.osx.yml',
                 'drush/config-delete.yml',
                 'drush/config-ignore.yml',
+                'dsh_bash',
                 'phpcs.xml',
                 'RoboFile.php',
                 'docker/standalone-memcached.xml',


### PR DESCRIPTION
Requires some steps to test:
update composer.json with:
```
"universityofadelaide/shepherd-drupal-scaffold": "dev-feature/auto-add-ssh-mac",
```
Then run:
```
rm docker-compose.osx.yml
composer update universityofadelaide/shepherd-drupal-scaffold
composer install
```

Then when you run ./dsh the dsh_bash will take care of setting up linux ones, or prompt if that doesn't work to load what is shared from your homedir.