### PR TITLE
Permit copy and customising stock docker-compose.yml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea/
 vendor
+docker-compose.yml

--- a/dsh
+++ b/dsh
@@ -21,6 +21,11 @@ else
   export DOCKER_COMPOSE_FILE='docker-compose.linux.yml'
 fi
 
+# Ultimately permit overriding repo docker-compose.yml with custom file.
+if [ -f docker-compose.yml ]; then
+  export DOCKER_COMPOSE_FILE='docker-compose.yml'
+fi
+
 # Set user variables
 export USER_ID=$(id -u ${USER})
 export GROUP_ID=$(id -g ${USER})


### PR DESCRIPTION
In some cases, I want to override checked in docker-compose.*.yml files by copying them to docker-compose.yml. For example to disable or override ports.

