### PR TITLE
Allow the selenium container to talk to the web server via 127.0.0.1.

### DIFF
--- a/docker-compose.linux.yml
+++ b/docker-compose.linux.yml
@@ -96,5 +96,4 @@ services:
     image: selenium/standalone-chrome:3.141.59-oxygen
     volumes:
       - /dev/shm:/dev/shm
-    networks:
-      - default
+    network_mode: service:web


### PR DESCRIPTION
Allow the selenium container to talk to the web server via 127.0.0.1.

On linux previously, you would need to edit phpunit.xml and use the name of the web container to run web tests. This change makes the selenium container "reuse another container's network stack" (from the docs @ https://docs.docker.com/engine/reference/run/#ipc-settings---ipc)