### PR TITLE
Feature/test networking

### DIFF
--- a/docker-compose.linux.yml
+++ b/docker-compose.linux.yml
@@ -12,9 +12,6 @@ services:
     ports:
       - "80:8080"
     environment:
-      DATABASE_HOST: 127.0.0.1
-      DATABASE_USER: user
-      DATABASE_PASSWORD: password
       HASH_SALT: random-hash
       MEMCACHE_ENABLED: 0
       MEMCACHE_HOST: memcached

--- a/docker-compose.linux.yml
+++ b/docker-compose.linux.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - "80:8080"
     environment:
-      DATABASE_HOST: db
+      DATABASE_HOST: 127.0.0.1
       DATABASE_USER: user
       DATABASE_PASSWORD: password
       HASH_SALT: random-hash
@@ -53,8 +53,7 @@ services:
       MYSQL_USER: user
       MYSQL_PASSWORD: password
       MYSQL_ROOT_PASSWORD: super-secret-password
-    networks:
-      - default
+    network_mode: service:web
 
   mail:
     image: mailhog/mailhog
@@ -93,7 +92,7 @@ services:
       - default
 
   selenium:
-    image: selenium/standalone-chrome:3.141.59-oxygen
+    image: selenium/standalone-chrome:latest
     volumes:
       - /dev/shm:/dev/shm
     network_mode: service:web


### PR DESCRIPTION
See phpunit.xml -  which is hardcoded to 127.0.0.1
```
<env name="SIMPLETEST_DB" value="mysql://user:password@127.0.0.1/drupal"/>
```
This PR aligns linux with osx docker-compose and lets tests run properly, because the containers can all talk nicely.

Database already moved to `network_mode: service:web` - so not a huge deal.

Latest Selenium image works fine now, because we use a Chrome option `"w3c": false`