### PR TITLE
Adding support for trusted host patterns.

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -210,6 +210,9 @@ class Handler
             "  \$settings['reverse_proxy_port_header'] = getenv('SHEPHERD_REVERSE_PROXY_PORT_HEADER') ?: 'X_FORWARDED_PORT';\n" .
             "  \$settings['reverse_proxy_forwarded_header'] = getenv('SHEPHERD_REVERSE_PROXY_FORWARDED_HEADER') ?: 'FORWARDED';\n" .
             "}\n" .
+            "if (getenv('TRUSTED_HOST_PATTERNS')) {\n" .
+            "  \$settings['trusted_host_patterns'] = !empty(getenv('TRUSTED_HOST_PATTERNS')) ? explode(',', getenv('TRUSTED_HOST_PATTERNS')) : [];\n" .
+            "}\n" .
             "/**\n * END SHEPHERD CONFIG\n */\n" .
             "\n" .
             "/**\n * START LOCAL CONFIG\n */\n" .


### PR DESCRIPTION
I've been seeing this a lot more locally:

"Redirects to external URLs are not allowed by default, use \Drupal\Core\Routing\TrustedRedirectResponse for it."

Pretty sure its because we need to do trusted host patterns.