### PR TITLE
Generate a salt before writing to disk, instead of generating on every page.

### DIFF
--- a/fixtures/php/settings.php.txt
+++ b/fixtures/php/settings.php.txt
@@ -17,7 +17,7 @@ $settings['file_temp_path'] = getenv('TMP_DIR') ?: '/shared/tmp';
 $settings['php_storage']['twig'] = [
   'directory' => (getenv('LOCAL_DIR') ?: DRUPAL_ROOT . '/..') . '/.php',
 ];
-$settings['hash_salt'] = getenv('HASH_SALT') ?: str_replace(['+', '/', '='], ['-', '_', ''], base64_encode(random_bytes(55)));
+$settings['hash_salt'] = getenv('HASH_SALT') ?: '<<<DEFAULT_HASH_SALT>>>';
 $config_directories['sync'] = DRUPAL_ROOT . '/../config-export';
 $settings['shepherd_site_id'] = getenv('SHEPHERD_SITE_ID');
 $settings['shepherd_url'] = getenv('SHEPHERD_URL');

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -148,7 +148,9 @@ class Handler
      */
     public function generateSettings()
     {
-      return file_get_contents(__DIR__ . '/../fixtures/php/settings.php.txt');
+      $settings = file_get_contents(__DIR__ . '/../fixtures/php/settings.php.txt');
+      $hashSalt = str_replace(['+', '/', '='], ['-', '_', ''], base64_encode(random_bytes(55)));
+      return str_replace('<<<DEFAULT_HASH_SALT>>>', $hashSalt, $settings);
     }
 
     /**


### PR DESCRIPTION
#87 remove the part where a default hash salt was generated and written to disk, and erroneously replaced it with generation on each page load if env var wasnt set.