### PR TITLE
Need to copy the custom ini file in the handler.

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -88,6 +88,7 @@ class Handler
                 'RoboFile.php',
                 'docker/Dockerfile',
                 'docker/xdebug.ini',
+                'docker/php_custom.ini',
             ]
         );
     }


### PR DESCRIPTION
After dsh purge, if the php_custom.ini wasn't there, it didn't get added.
Needs to be transferred with the Handler.