### PR TITLE
Remove unused libnotify to avoid installing all the dependencies.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,7 +31,7 @@ fi
 
 # Upgrade all currently installed packages and install additional packages.
 RUN apt-get update \
-&& apt-get -y install php-sqlite3 php-xdebug php-cli git wget sudo unzip libnotify-bin vim \
+&& apt-get -y install php-sqlite3 php-xdebug php-cli git wget sudo unzip vim \
 && sed -ri 's/^zend.assertions\s*=\s*-1/zend.assertions = 1/g' /etc/php/${PHP_VERSION}/cli/php.ini \
 && sed -i 's/^\(allow_url_fopen\s*=\s*\).*$/\1on/g' /etc/php/${PHP_VERSION}/mods-available/php_custom.ini \
 && apt-get -y autoremove && apt-get -y autoclean && apt-get clean && rm -rf /var/lib/apt/lists /tmp/* /var/tmp/*


### PR DESCRIPTION
I'm not sure why we're installing this, but it installs xserver... so 600+ packages and 1GB of "stuff". Let's remove it.

I guess it may have related to chrome web driver, but that's spun out into its own container, so it's not useful at all - if that was the reason.