### PR TITLE
Adds compatibility layer to run independent of D8/9 version.

### DIFF
--- a/scaffold/required/RoboFileBase.php
+++ b/scaffold/required/RoboFileBase.php
@@ -335,6 +335,8 @@ abstract class RoboFileBase extends Tasks {
 
   /**
    * Config import backwards compatibility for restore/upgrade.
+   *
+   * @deprecated To be removed once all apps move to D9.
    */
   public function configImportPlus() {
     $this->configImport();

--- a/scaffold/required/RoboFileBase.php
+++ b/scaffold/required/RoboFileBase.php
@@ -334,6 +334,13 @@ abstract class RoboFileBase extends Tasks {
   }
 
   /**
+   * Config import backwards compatibility for restore/upgrade.
+   */
+  public function configImportPlus() {
+    $this->configImport();
+  }
+
+  /**
    * Exports Drupal configuration.
    *
    * @param string|null $destination


### PR DESCRIPTION
Otherwise our backup/restore is going to need to determine version. Easier to just add compatibility layer here and remove configImportPlus() later.