### PR TITLE
Only required files should be in .gitignore - controlled by scaffold.

### DIFF
--- a/src/actions/GitIgnore.php
+++ b/src/actions/GitIgnore.php
@@ -42,7 +42,8 @@ final class GitIgnore implements ActionInterface
         $gitIgnore = file_get_contents($gitIgnorePath);
 
         // Get list of file paths which need to be added to .gitignore.
-        $fileTasks = ScaffoldFiles::tasks($filesystem, $scaffoldPath, $projectPath);
+        $requiredPath = $scaffoldPath . '/required';
+        $fileTasks = ScaffoldFiles::tasks($filesystem, $requiredPath, $projectPath);
         $paths = array_filter(
             array_map(fn (CopyFile $task) => $task->getFilename(), $fileTasks),
             fn (string $fileName): bool => false === strpos($gitIgnore, $fileName)


### PR DESCRIPTION
Overzealously poopulating .gitignore :)

This PR restricts appending scaffold files to the .gitignore to just required files, which are not project specific and controlled exclusively by the scaffold.