### PR TITLE
Adds all the Drupal related file extensions to PHPCS.

### DIFF
--- a/scaffold/optional/phpcs.xml
+++ b/scaffold/optional/phpcs.xml
@@ -15,6 +15,7 @@
   <exclude-pattern>*dist/*.js</exclude-pattern>
   <!-- additional arguments -->
   <arg name="report" value="full"/>
+  <arg name="extensions" value="php,module,inc,install,test,profile,theme,css,info,txt,md,yml"/>
   <!-- inherit from coder -->
   <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal"/>
   <!-- Additional detailed sniff configuration -->


### PR DESCRIPTION
I don't know how we got this far without this... but apparently we weren't checking all file extensions... which I discovered when running phpcs manually with -v.