### PR TITLE
Add in delete function as pert of the file scaffolding.

### DIFF
--- a/src/actions/ScaffoldFiles.php
+++ b/src/actions/ScaffoldFiles.php
@@ -28,7 +28,7 @@ final class ScaffoldFiles implements ActionInterface
         }
 
         $event->getIO()->write('Deleting install.php');
-        $delete = new DeleteFile($this->filesystem, 'core/web', 'install.php');
+        $delete = new DeleteFile($this->filesystem, 'web/core', 'install.php');
         $delete->execute();
     }
 

--- a/src/actions/ScaffoldFiles.php
+++ b/src/actions/ScaffoldFiles.php
@@ -8,6 +8,7 @@ use Composer\Script\Event;
 use Symfony\Component\Filesystem\Filesystem;
 use UniversityOfAdelaide\ShepherdDrupalScaffold\ScaffoldTrait;
 use UniversityOfAdelaide\ShepherdDrupalScaffold\tasks\CopyFile;
+use UniversityOfAdelaide\ShepherdDrupalScaffold\tasks\DeleteFile;
 
 /**
  * Updates the Shepherd scaffold files.
@@ -25,6 +26,9 @@ final class ScaffoldFiles implements ActionInterface
         foreach (static::tasks($this->filesystem, $scaffoldPath, $projectPath) as $task) {
             $task->execute();
         }
+
+        $delete = new DeleteFile($this->filesystem, 'core/web', 'install.php');
+        $delete->execute();
     }
 
     /**

--- a/src/actions/ScaffoldFiles.php
+++ b/src/actions/ScaffoldFiles.php
@@ -27,6 +27,7 @@ final class ScaffoldFiles implements ActionInterface
             $task->execute();
         }
 
+        $event->getIO()->write('Deleting install.php');
         $delete = new DeleteFile($this->filesystem, 'core/web', 'install.php');
         $delete->execute();
     }

--- a/src/tasks/DeleteFile.php
+++ b/src/tasks/DeleteFile.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UniversityOfAdelaide\ShepherdDrupalScaffold\tasks;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+class DeleteFile implements TaskInterface
+{
+    protected Filesystem $filesystem;
+    protected string $path;
+    protected string $filename;
+
+    public function __construct(Filesystem $filesystem, string $path, string $filename)
+    {
+        $this->filesystem = $filesystem;
+        $this->path = $path;
+        $this->filename = $filename;
+    }
+
+    public function getFilename(): string
+    {
+        return $this->filename;
+    }
+
+    /**
+     * @throws \Symfony\Component\Filesystem\Exception\FileNotFoundException
+     *   When original file doesn't exist
+     * @throws \Symfony\Component\Filesystem\Exception\IOException
+     *   When copy fails
+     */
+    public function execute(): void
+    {
+        // Skip copying files that already exist at the destination.
+        if (!$this->filesystem->exists($this->path . '/' . $this->filename)) {
+            return;
+        }
+
+        $this->filesystem->remove(
+            $this->path . '/' . $this->filename
+        );
+    }
+}


### PR DESCRIPTION
We have addressed this in the RoboFile.php with the code below, but guess what we don't to for wcms installations. I've addressed with a configmap for now, but we need to remove if after composer install, as per the changes suggested, which still need testing.

```
  /**
   * Remove install.php to prevent DoS attacks.
   *
   * 'install.php' creates a table in the database, which combined with database
   * replication, can cause Galera to crash from too many create and delete
   * operations.
   */
  public function buildMake($flags = '') {
    parent::buildMake($flags);
    $this->taskFilesystemStack()
      ->remove($this->application_root . '/core/install.php')
      ->run();
  }
```