### PR TITLE
Log to /tmp and disable forced start to prevent cli logging.

### DIFF
--- a/scaffold/optional/docker/xdebug.ini
+++ b/scaffold/optional/docker/xdebug.ini
@@ -1,6 +1,7 @@
 zend_extension=xdebug.so
 xdebug.max_nesting_level=500
 xdebug.mode=debug,develop
-xdebug.start_with_request=yes
+#xdebug.start_with_request=yes
 xdebug.client_host=host.docker.internal
 xdebug.client_discovery_header=HTTP_X_FORWARDED_FOR,REMOTE_ADDR
+xdebug.output_dir=/tmp/xdebug


### PR DESCRIPTION
Stops the millions of:
```
Xdebug: [Step Debug] Could not connect to debugging client. Tried: host.docker.internal:9003 (through xdebug.client_host/xdebug.client_port) :-(
```