### PR TITLE
DXPO-1129 Sites using URL discovery for Media oEmbed providers must a…

### DIFF
--- a/fixtures/php/settings.php.txt
+++ b/fixtures/php/settings.php.txt
@@ -79,6 +79,20 @@ if (getenv('SHEPHERD_REVERSE_PROXY')) {
 if (getenv('TRUSTED_HOST_PATTERNS')) {
   $settings['trusted_host_patterns'] = !empty(getenv('TRUSTED_HOST_PATTERNS')) ? explode(',', getenv('TRUSTED_HOST_PATTERNS')) : [];
 }
+
+/**
+ * Configure trusted oEmbed provider host patterns.
+ *
+ * Sets trusted host patterns for Media oEmbed URL discovery from the
+ * MEDIA_OEMBED_DISCOVERY_TRUSTED_HOST_PATTERNS environment variable.
+ */
+if (getenv('MEDIA_OEMBED_DISCOVERY_TRUSTED_HOST_PATTERNS')) {
+  $settings['media_oembed_discovery_trusted_host_patterns'] =
+    !empty(getenv('MEDIA_OEMBED_DISCOVERY_TRUSTED_HOST_PATTERNS'))
+      ? explode(',', getenv('MEDIA_OEMBED_DISCOVERY_TRUSTED_HOST_PATTERNS'))
+      : [];
+}
+
 /**
  * END SHEPHERD CONFIG
  */

--- a/fixtures/php/settings.php.txt
+++ b/fixtures/php/settings.php.txt
@@ -86,8 +86,13 @@ if (getenv('TRUSTED_HOST_PATTERNS')) {
  * Sets trusted host patterns for Media oEmbed URL discovery from the
  * MEDIA_OEMBED_DISCOVERY_TRUSTED_HOST_PATTERNS environment variable.
  */
-if (getenv('MEDIA_OEMBED_DISCOVERY_TRUSTED_HOST_PATTERNS') && !empty(getenv('MEDIA_OEMBED_DISCOVERY_TRUSTED_HOST_PATTERNS'))) {
-  $settings['media_oembed_discovery_trusted_host_patterns'] = explode(',', getenv('MEDIA_OEMBED_DISCOVERY_TRUSTED_HOST_PATTERNS'));
+$media_oembed_discovery_trusted_host_patterns = getenv('MEDIA_OEMBED_DISCOVERY_TRUSTED_HOST_PATTERNS');
+
+if ($media_oembed_discovery_trusted_host_patterns !== false && $media_oembed_discovery_trusted_host_patterns !== '') {
+  $settings['media_oembed_discovery_trusted_host_patterns'] = array_map(
+    'trim',
+    explode(',', $media_oembed_discovery_trusted_host_patterns)
+  );
 }
 
 /**

--- a/fixtures/php/settings.php.txt
+++ b/fixtures/php/settings.php.txt
@@ -86,11 +86,8 @@ if (getenv('TRUSTED_HOST_PATTERNS')) {
  * Sets trusted host patterns for Media oEmbed URL discovery from the
  * MEDIA_OEMBED_DISCOVERY_TRUSTED_HOST_PATTERNS environment variable.
  */
-if (getenv('MEDIA_OEMBED_DISCOVERY_TRUSTED_HOST_PATTERNS')) {
-  $settings['media_oembed_discovery_trusted_host_patterns'] =
-    !empty(getenv('MEDIA_OEMBED_DISCOVERY_TRUSTED_HOST_PATTERNS'))
-      ? explode(',', getenv('MEDIA_OEMBED_DISCOVERY_TRUSTED_HOST_PATTERNS'))
-      : [];
+if (getenv('MEDIA_OEMBED_DISCOVERY_TRUSTED_HOST_PATTERNS') && !empty(getenv('MEDIA_OEMBED_DISCOVERY_TRUSTED_HOST_PATTERNS'))) {
+  $settings['media_oembed_discovery_trusted_host_patterns'] = explode(',', getenv('MEDIA_OEMBED_DISCOVERY_TRUSTED_HOST_PATTERNS'));
 }
 
 /**


### PR DESCRIPTION
Sites using URL discovery for Media oEmbed providers must add an additional media_oembed_discovery_trusted_host_patterns entry to settings.php for their list of known oEmbed providers (like YouTube and Vimeo). It is an array containing a series of regular expressions for matching host names for discovery. It follows the same pattern as the existing [trusted hosts settings](https://www.drupal.org/docs/getting-started/installing-drupal/trusted-host-settings).

Reference :- https://www.drupal.org/project/drupal/releases/11.3.12 